### PR TITLE
Fix some naming errors

### DIFF
--- a/manifests/rules/openfire.pp
+++ b/manifests/rules/openfire.pp
@@ -1,5 +1,5 @@
 class shorewall::rules::openfire {
-  include shorewall::rules::jaberserver
+  include shorewall::rules::jabberserver
 
   shorewall::rule { 'me-all-openfire-tcp':
     source          => '$FW',

--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -1,14 +1,14 @@
 define shorewall::zone(
     $type,
     $options = '-',
-    $in = '-',
+    $in_ = '-',
     $out = '-',
     $parent = '-',
     $order = 100
 ){
     $real_name = $parent ? { '-' => $name, default => "${name}:${parent}" }
     shorewall::entry { "zones-${order}-${name}":
-        line => "${real_name} ${type} ${options} ${in} ${out}"
+        line => "${real_name} ${type} ${options} ${in_} ${out}"
     }
 }
 


### PR DESCRIPTION
The typo on "jaberserver" is quite safe.

For shorewall::zone, this may lead to regression, so you might want to chose another naming: "in" is (now ?) a reserved keyword on Puppet and cannot be used, see https://docs.puppetlabs.com/puppet/latest/reference/lang_reserved.html
