### PR TITLE
patched centos class for CentOS 7, puppet 4 compatibility

### DIFF
--- a/manifests/centos.pp
+++ b/manifests/centos.pp
@@ -1,13 +1,32 @@
 # things needed on centos
 class shorewall::centos inherits shorewall::base {
-  if $::operatingsystemmajrelease > 5 {
-    augeas{'enable_shorewall':
-      context => '/files/etc/sysconfig/shorewall',
-      changes => 'set startup 1',
-      lens    => 'Shellvars.lns',
-      incl    => '/etc/sysconfig/shorewall',
-      require => Package['shorewall'],
-      notify  => Service['shorewall'],
+
+  if !$shorewall::conf_source {
+
+    if $::operatingsystemmajrelease > '6' {
+
+      # CentOS 7.x
+      augeas{'enable_shorewall_config':
+        context => '/files/etc/shorewall/shorewall.conf',
+        changes => 'set STARTUP_ENABLED yes',
+        lens    => 'Shellvars.lns',
+        incl    => '/etc/shorewall/shorewall.conf',
+        require => Package['shorewall'],
+        notify  => Service['shorewall'],
+      }
+
+    } else {
+
+      # Caters for CentOS 5.x, 6.x
+      augeas{'enable_shorewall':
+        context => '/files/etc/sysconfig/shorewall',
+        changes => 'set startup 1',
+        lens    => 'Shellvars.lns',
+        incl    => '/etc/sysconfig/shorewall',
+        require => Package['shorewall'],
+        notify  => Service['shorewall'],
+      }
     }
   }
+
 }


### PR DESCRIPTION
Updated to make compatible with CentOS 7 (ref: https://github.com/duritong/puppet-shorewall/pull/11) and also changed comparison of return value to compare to a string (puppet 4.x compatibility).
