### PR TITLE
Added $host option

### DIFF
--- a/manifests/host.pp
+++ b/manifests/host.pp
@@ -1,10 +1,11 @@
 define shorewall::host(
     $zone,
+    $host,
     $options = 'tcpflags,blacklist,norfc1918',
     $order='100'
 ){
     shorewall::entry{"hosts-${order}-${name}":
-        line => "${zone} ${name} ${options}"
+        line => "#${name}\n${zone} ${host} ${options}"
     }
 }
 

--- a/manifests/host.pp
+++ b/manifests/host.pp
@@ -1,13 +1,9 @@
 define shorewall::host(
     $zone,
-    $host = undef,
+    $host = $name,
     $options = 'tcpflags,blacklist,norfc1918',
     $order ='100'
 ){
-    
-    unless $host == undef {
-      $host = $name
-    }
 
     shorewall::entry{"hosts-${order}-${name}":
         line => "#${name}\n${zone} ${host} ${options}"

--- a/manifests/host.pp
+++ b/manifests/host.pp
@@ -1,11 +1,15 @@
 define shorewall::host(
     $zone,
-    $host,
+    $host = undef,
     $options = 'tcpflags,blacklist,norfc1918',
-    $order='100'
+    $order ='100'
 ){
+    
+    unless $host == undef {
+      $host = $name
+    }
+
     shorewall::entry{"hosts-${order}-${name}":
         line => "#${name}\n${zone} ${host} ${options}"
     }
 }
-


### PR DESCRIPTION
Current host.pp converts the $name into the "HOST" parameter. This can result in these definitions:

```puppet
shorewall::host { 'eth0:$VPN_HOSTS':
  zone => 'vpn',
  options => 'ipsec',
  order => 200;
}
```

I suggest moving the variable usage from the $name into a $host parameter, so above example becomes:

```puppet
shorewall::host { 'vpn-hosts':
  zone => 'vpn',
  host => 'eth0:$VPN_HOSTS',
  options => 'ipsec',
  order => 200;
}
```