### PR TITLE
Removed $ensure param

### DIFF
--- a/manifests/conntrack/helper.pp
+++ b/manifests/conntrack/helper.pp
@@ -4,7 +4,6 @@
 # The $name defines the helper, so this needs to match one of the helpers
 # in the documentation.
 define shorewall::conntrack::helper(
-  $ensure = present,
   $options = '',
   $source = '-',
   $destination = '-',
@@ -26,7 +25,6 @@ define shorewall::conntrack::helper(
   }
 
   shorewall::entry{"conntrack-${order}-${name}":
-    ensure => $ensure,
     line => "?if ${_helper}\nCT:helper:${name}${_options}${_chain} ${source} ${destination} ${proto} ${destinationport} ${sourceport} ${$user} ${switch}\n?endif"
   }
 }

--- a/manifests/entry.pp
+++ b/manifests/entry.pp
@@ -1,6 +1,5 @@
 # a core wrapper for all kinds of entries
 define shorewall::entry(
-    $ensure     = present,
     $shorewall  = true,
     $shorewall6 = false,
     $line
@@ -8,7 +7,6 @@ define shorewall::entry(
   $parts = split($name,'-')
   if $shorewall {
     concat::fragment{$name:
-      ensure  => $ensure,
       content => "${line}\n",
       order   => $parts[1],
       target  => "/etc/shorewall/puppet/${parts[0]}",
@@ -16,7 +14,6 @@ define shorewall::entry(
   }
   if $shorewall6 and $shorewall::with_shorewall6 {
     concat::fragment{"shorewall6_${name}":
-      ensure  => $ensure,
       content => "${line}\n",
       order   => $parts[1],
       target  => "/etc/shorewall6/puppet/${parts[0]}",

--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -19,7 +19,6 @@ define shorewall::rule(
   $order           = '500',
   $shorewall       = true,
   $shorewall6      = false,
-  $ensure          = 'present',
 ){
   if versioncmp($shorewall_version,'4.5.7') >= 0 {
     $line = " ${connlimit} ${time} ${headers} ${switch} ${helper}"
@@ -31,7 +30,6 @@ define shorewall::rule(
     $line = ''
   }
   shorewall::entry{"rules-${order}-${name}":
-    ensure     => $ensure,
     line       => "# ${name}\n${action} ${source} ${destination} ${proto} ${destinationport} ${sourceport} ${originaldest} ${ratelimit} ${user} ${mark}${line}",
     shorewall  => $shorewall,
     shorewall6 => $shorewall6,

--- a/manifests/rule4.pp
+++ b/manifests/rule4.pp
@@ -16,11 +16,9 @@ define shorewall::rule4(
   $switch          = '-',
   $helper          = '-',
   $order           = '500',
-  $ensure          = 'present',
 ){
   shorewall::rule{
     $name:
-      ensure          => $ensure,
       action          => $action,
       source          => $source,
       destination     => $destination,

--- a/manifests/rule6.pp
+++ b/manifests/rule6.pp
@@ -16,11 +16,9 @@ define shorewall::rule6(
   $switch          = '-',
   $helper          = '-',
   $order           = '500',
-  $ensure          = 'present',
 ){
   shorewall::rule{
     $name:
-      ensure          => $ensure,
       action          => $action,
       source          => $source,
       destination     => $destination,

--- a/manifests/rules/gitdaemon/absent.pp
+++ b/manifests/rules/gitdaemon/absent.pp
@@ -1,5 +1,5 @@
 class shorewall::rules::gitdaemon::absent inherits shorewall::rules::gitdaemon {
   Shorewall::Rule['net-me-tcp_gitdaemon']{
-    content = '',
+    content => '',
   }
 }

--- a/manifests/rules/gitdaemon/absent.pp
+++ b/manifests/rules/gitdaemon/absent.pp
@@ -1,5 +1,5 @@
 class shorewall::rules::gitdaemon::absent inherits shorewall::rules::gitdaemon {
   Shorewall::Rule['net-me-tcp_gitdaemon']{
-    ensure => absent,
+    content = '',
   }
 }

--- a/manifests/rules/out/ssh/remove.pp
+++ b/manifests/rules/out/ssh/remove.pp
@@ -1,5 +1,5 @@
 class shorewall::rules::out::ssh::remove inherits shorewall::rules::out::ssh {
   Shorewall::Rule['me-net-tcp_ssh']{
-    ensure => absent,
+    content => '',
   }
 }


### PR DESCRIPTION
Removed the $ensure parameter from various items. This parameter is deprecated in puppetlabs-concat 3.0.0 and 4.0.0 and is removed in the latest 4.0.1.

**These changes make the module dependant on puppetlabs-concat 4.0.1 and will only be compatible with puppet 4.7.0 and up.**

Something to think about before merging.