### PR TITLE
Fix configuration directory passed to "shorewall try".

### DIFF
--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -85,7 +85,7 @@ class shorewall::base {
     refreshonly => true,
     require     => Package['shorewall'],
   } ~> exec{'shorewall_try':
-    command     => 'shorewall try /etc/shorewall/puppet',
+    command     => 'shorewall try /etc/shorewall',
     refreshonly => true,
   } -> service{'shorewall':
     ensure     => running,
@@ -112,7 +112,7 @@ class shorewall::base {
       refreshonly => true,
       require     => Package['shorewall6'],
     } ~> exec{'shorewall6_try':
-      command     => 'shorewall6 try /etc/shorewall6/puppet',
+      command     => 'shorewall6 try /etc/shorewall6',
       refreshonly => true,
     } -> service{'shorewall6':
       ensure     => running,


### PR DESCRIPTION
This command takes as argument the directory that contains shorewall.conf,
not the CONFIG_PATH where files like "interfaces" and "zones" live.

This is a cherry-pick from https://gitlab.com/shared-puppet-modules-group/shorewall/commit/ce9dab0ffc2876a9ea576e2fa99065104ac9f423